### PR TITLE
fix: Pose Info 엔티티 변경

### DIFF
--- a/src/main/java/com/dndoz/PosePicker/Domain/PoseInfo.java
+++ b/src/main/java/com/dndoz/PosePicker/Domain/PoseInfo.java
@@ -5,35 +5,62 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
+
+import com.dndoz.PosePicker.Global.entity.BaseEntity;
 
 import io.swagger.annotations.ApiModel;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @AllArgsConstructor
-@Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "pose_info")
-@Getter
-@Setter
-
+@Table(name = "pose_info")
 @ApiModel(value = "포즈 이미지 모델: PoseInfo")
-public class PoseInfo {
+public class PoseInfo extends BaseEntity {
 	@Column(name = "image_key")
-	String image_key;
+	String imageKey;
 	@Column(name = "source")
-	String pose_source;
+	String source;
+	@Column(name = "source_url")
+	String sourceUrl;
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long pose_id;
+	private Long poseId;
 	@Column(name = "people_count")
-	private Integer people_count;
+	private Integer peopleCount;
 
 	@Column(name = "frame_count")
-	private Integer frame_count;
+	private Integer frameCount;
+
+	public Long getPoseId() {
+		return poseId;
+	}
+
+	public String getImageKey() {
+		return imageKey;
+	}
+
+	public void setImageKey(String imageKey) {
+		this.imageKey = imageKey;
+	}
+
+	public String getSource() {
+		return source;
+	}
+
+	public String getSourceUrl() {
+		return sourceUrl;
+	}
+
+	public Integer getPeopleCount() {
+		return peopleCount;
+	}
+
+	public Integer getFrameCount() {
+		return frameCount;
+	}
 
 }

--- a/src/main/java/com/dndoz/PosePicker/Repository/PoseInfoRepository.java
+++ b/src/main/java/com/dndoz/PosePicker/Repository/PoseInfoRepository.java
@@ -1,5 +1,7 @@
 package com.dndoz.PosePicker.Repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -9,5 +11,5 @@ import com.dndoz.PosePicker.Domain.PoseInfo;
 @Repository
 public interface PoseInfoRepository extends JpaRepository<PoseInfo, Long> {
 	@Query(value = "SELECT * FROM pose_info WHERE (:people_count < 5 AND people_count = :people_count) OR (:people_count >= 5 AND people_count >= 5) ORDER BY RAND() LIMIT 1", nativeQuery = true)
-	PoseInfo findRandomPoseInfo(Integer people_count);
+	Optional<PoseInfo> findRandomPoseInfo(Integer people_count);
 }

--- a/src/main/java/com/dndoz/PosePicker/Service/PoseService.java
+++ b/src/main/java/com/dndoz/PosePicker/Service/PoseService.java
@@ -1,8 +1,8 @@
 package com.dndoz.PosePicker.Service;
 
 import java.util.List;
-import java.util.Optional;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,8 +13,8 @@ import com.dndoz.PosePicker.Dto.PoseInfoResponse;
 import com.dndoz.PosePicker.Dto.PoseTagAttributeResponse;
 import com.dndoz.PosePicker.Dto.PoseTalkResponse;
 import com.dndoz.PosePicker.Repository.PoseInfoRepository;
-import com.dndoz.PosePicker.Repository.PoseTalkRepository;
 import com.dndoz.PosePicker.Repository.PoseTagAttributeRepository;
+import com.dndoz.PosePicker.Repository.PoseTalkRepository;
 
 @Transactional(readOnly = true)
 @Service
@@ -22,6 +22,8 @@ public class PoseService {
 	private final PoseInfoRepository poseInfoRepository;
 	private final PoseTalkRepository poseTalkRepository;
 	private final PoseTagAttributeRepository poseTagAttributeRepository;
+	@Value("${aws.imageUrl.prefix}")
+	private String urlPrefix;
 
 	public PoseService(final PoseInfoRepository poseInfoRepository, final PoseTalkRepository poseTalkRepository,
 		final PoseTagAttributeRepository poseTagAttributeRepository) {
@@ -32,17 +34,14 @@ public class PoseService {
 
 	//포즈 이미지 상세 조회
 	public PoseInfoResponse getPoseInfo(Long pose_id) {
-		Optional<PoseInfo> optionalPoseInfo = poseInfoRepository.findById(pose_id);
-		if (optionalPoseInfo.isPresent()) {
-			return new PoseInfoResponse(optionalPoseInfo.get());
-		} else {
-			return null;
-		}
+		PoseInfo poseInfo = poseInfoRepository.findById(pose_id).orElseThrow(NullPointerException::new);
+		poseInfo.setImageKey(urlPrefix + poseInfo.getImageKey());
+		return new PoseInfoResponse(poseInfo);
 	}
 
 	//포즈픽(사진) 조회
 	public PoseInfoResponse showRandomPoseInfo(Integer people_count) {
-		PoseInfo poseInfo = poseInfoRepository.findRandomPoseInfo(people_count);
+		PoseInfo poseInfo = poseInfoRepository.findRandomPoseInfo(people_count).orElseThrow(NullPointerException::new);
 		return new PoseInfoResponse(poseInfo);
 	}
 


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- source url 및 source 데이터 추가에 따른 Pose Info 엔티티 변경

<br>

## 💁 무엇이 어떻게 바뀌나요?

1. PoseInfo 엔티티에 `source_url` , `source` 추가했습니다!
2. 기존에 raw url 이 중복되어서 해당 사항 DB에는 bucket key 저장으로, 
서비스 로직에 bucket key에 prefix 덧붙여서 데이터 중복 저장 방지했습니다!

<br>

## 📆 작업 예정인 것이 있나요 ?

- PoseInfo 필터링 API

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, design, refactor, test, add, set, docs, chore
-->
