### PR TITLE
feat: 카카오 로그인 API 및 jwt 토큰 발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,16 +24,22 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'io.springfox:springfox-boot-starter:3.0.0'
-	implementation 'mysql:mysql-connector-java:8.0.28'
+	//implementation 'io.springfox:springfox-boot-starter:3.0.0'
+	//implementation 'mysql:mysql-connector-java:8.0.28'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'com.mysql:mysql-connector-j'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	//implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	//implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation group: 'io.springfox', name: 'springfox-boot-starter', version: '3.0.0'
+
+	//
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation group: 'org.json', name: 'json', version: '20160810'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dndoz/PosePicker/Auth/AuthTokens.java
+++ b/src/main/java/com/dndoz/PosePicker/Auth/AuthTokens.java
@@ -1,0 +1,21 @@
+package com.dndoz.PosePicker.Auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthTokens {
+    private String accessToken;
+    private String refreshToken;
+    private String grantType;
+    private Long expiresIn;
+
+    public static AuthTokens of(String accessToken, String refreshToken, String grantType, Long expiresIn) {
+        return new AuthTokens(accessToken, refreshToken, grantType, expiresIn);
+    }
+}

--- a/src/main/java/com/dndoz/PosePicker/Auth/AuthTokensGenerator.java
+++ b/src/main/java/com/dndoz/PosePicker/Auth/AuthTokensGenerator.java
@@ -1,0 +1,34 @@
+package com.dndoz.PosePicker.Auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class AuthTokensGenerator {
+    private static final String BEARER_TYPE = "Bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    //email 받아 Access Token 생성
+    public AuthTokens generate(String email) {
+        long now = (new Date()).getTime();
+        Date accessTokenExpiredAt = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        Date refreshTokenExpiredAt = new Date(now + REFRESH_TOKEN_EXPIRE_TIME);
+
+        //String subject = email.toString();
+        String accessToken = jwtTokenProvider.generate(email, accessTokenExpiredAt);
+        String refreshToken = jwtTokenProvider.generate(email, refreshTokenExpiredAt);
+
+        return AuthTokens.of(accessToken, refreshToken, BEARER_TYPE, ACCESS_TOKEN_EXPIRE_TIME / 1000L);
+    }
+
+    // Access Token 에서 email 추출
+    public Long extractEmail(String accessToken) {
+        return Long.valueOf(jwtTokenProvider.extractSubject(accessToken));
+    }
+}

--- a/src/main/java/com/dndoz/PosePicker/Auth/JwtTokenProvider.java
+++ b/src/main/java/com/dndoz/PosePicker/Auth/JwtTokenProvider.java
@@ -1,0 +1,49 @@
+package com.dndoz.PosePicker.Auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    private final Key key;
+
+    public JwtTokenProvider(@Value("${custom.jwt.secretKey}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String generate(String subject, Date expiredAt) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .setExpiration(expiredAt)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public String extractSubject(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+        return claims.getSubject();
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
+++ b/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
@@ -1,0 +1,35 @@
+package com.dndoz.PosePicker.Controller;
+
+import com.dndoz.PosePicker.Dto.LoginResponse;
+import com.dndoz.PosePicker.Service.UserService;
+import io.swagger.annotations.Api;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.NoSuchElementException;
+
+@RestController
+@RequestMapping("/api/users")
+@Api(tags = {"유저 API"})
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @ResponseBody
+    @GetMapping("/login/oauth/kakao")
+    public ResponseEntity<LoginResponse> kakaoLogin(@RequestParam String code){
+        try{
+            return ResponseEntity.ok(userService.kakaoLogin(code));
+        } catch (NoSuchElementException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,"Item Not Found");
+        }
+    }
+
+}
+

--- a/src/main/java/com/dndoz/PosePicker/Domain/User.java
+++ b/src/main/java/com/dndoz/PosePicker/Domain/User.java
@@ -13,7 +13,7 @@ import javax.persistence.*;
 @ApiModel(value="사용자 모델: User")
 public class User {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="uid")
     private Long uid;
 
     @Column(name = "nickname")
@@ -21,7 +21,6 @@ public class User {
 
     @Column(name = "email")
     String email;
-
 
     public User(Long uid, String nickname, String email){
         this.uid=uid;

--- a/src/main/java/com/dndoz/PosePicker/Domain/User.java
+++ b/src/main/java/com/dndoz/PosePicker/Domain/User.java
@@ -1,0 +1,32 @@
+package com.dndoz.PosePicker.Domain;
+
+import com.dndoz.PosePicker.Global.entity.BaseEntity;
+import io.swagger.annotations.ApiModel;
+import lombok.*;
+
+import javax.persistence.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name="user")
+@Getter
+@Setter
+@ApiModel(value="사용자 모델: User")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long uid;
+
+    @Column(name = "nickname")
+    String nickname;
+
+    @Column(name = "email")
+    String email;
+
+
+    public User(Long uid, String nickname, String email){
+        this.uid=uid;
+        this.nickname=nickname;
+        this.email=email;
+    }
+
+}

--- a/src/main/java/com/dndoz/PosePicker/Dto/LoginResponse.java
+++ b/src/main/java/com/dndoz/PosePicker/Dto/LoginResponse.java
@@ -1,0 +1,18 @@
+package com.dndoz.PosePicker.Dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@Getter
+@NoArgsConstructor
+public class LoginResponse {
+    private Long id;
+    private String nickname;
+    private String email;
+
+    public LoginResponse(Long id, String nickname, String email) {
+        this.id = id;
+        this.nickname = nickname;
+        this.email = email;
+    }
+
+}

--- a/src/main/java/com/dndoz/PosePicker/Dto/LoginResponse.java
+++ b/src/main/java/com/dndoz/PosePicker/Dto/LoginResponse.java
@@ -1,5 +1,6 @@
 package com.dndoz.PosePicker.Dto;
 
+import com.dndoz.PosePicker.Auth.AuthTokens;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 @Getter
@@ -8,11 +9,12 @@ public class LoginResponse {
     private Long id;
     private String nickname;
     private String email;
+    private AuthTokens token;
 
-    public LoginResponse(Long id, String nickname, String email) {
+    public LoginResponse(Long id, String nickname, String email, AuthTokens token) {
         this.id = id;
         this.nickname = nickname;
         this.email = email;
+        this.token = token;
     }
-
 }

--- a/src/main/java/com/dndoz/PosePicker/Repository/UserRepository.java
+++ b/src/main/java/com/dndoz/PosePicker/Repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.dndoz.PosePicker.Repository;
+
+import com.dndoz.PosePicker.Domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User,Long> {
+
+    Optional<User> findByEmail(@Param("email") String email);
+}

--- a/src/main/java/com/dndoz/PosePicker/Service/UserService.java
+++ b/src/main/java/com/dndoz/PosePicker/Service/UserService.java
@@ -38,7 +38,7 @@ public class UserService {
         HashMap<String, Object> userInfo= getKakaoUserInfo(accessToken);
 
         //3. 카카오ID로 회원가입 & 로그인 처리
-        LoginResponse kakaoUserResponse= kakaoLogin(userInfo);
+        LoginResponse kakaoUserResponse= kakaoUserLogin(userInfo);
 
         return kakaoUserResponse;
     }
@@ -127,9 +127,9 @@ public class UserService {
     }
 
     //3. 카카오ID로 회원가입 & 로그인 처리
-    private LoginResponse kakaoLogin(HashMap<String, Object> userInfo){
-        Long uid=null;
-        Long kakaoId= Long.valueOf(userInfo.get("id").toString());
+    private LoginResponse kakaoUserLogin(HashMap<String, Object> userInfo){
+
+        Long uid= Long.valueOf(userInfo.get("id").toString());
         String kakaoEmail = userInfo.get("email").toString();
         String nickName = userInfo.get("nickname").toString();
 
@@ -137,8 +137,8 @@ public class UserService {
                 .orElse(null);
 
         if (kakaoUser == null) {    //회원가입
-            kakaoUser = new User(kakaoId, nickName, kakaoEmail);
-            uid=userRepository.save(kakaoUser).getUid();
+            kakaoUser = new User(uid, nickName, kakaoEmail);
+            userRepository.save(kakaoUser);
         }
 
         //토큰 생성

--- a/src/main/java/com/dndoz/PosePicker/Service/UserService.java
+++ b/src/main/java/com/dndoz/PosePicker/Service/UserService.java
@@ -1,0 +1,136 @@
+package com.dndoz.PosePicker.Service;
+
+import com.dndoz.PosePicker.Domain.User;
+import com.dndoz.PosePicker.Dto.LoginResponse;
+import com.dndoz.PosePicker.Repository.UserRepository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public LoginResponse kakaoLogin(String code) {
+        // 1. "인가 코드"로 "액세스 토큰" 요청
+        String accessToken = getAccessToken(code);
+
+        // 2. 토큰으로 카카오 API 호출
+        LoginResponse kakaoUserInfo = getKakaoUserInfo(accessToken);
+
+        // 3. 카카오ID로 회원가입 처리
+        User kakaoUser = registerKakaoUserIfNeed(kakaoUserInfo);
+
+        return kakaoUserInfo;
+    }
+
+    @Value("${kakao.key.client-id}")
+    private String clientId;
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+
+    // "인가 코드"로 "액세스 토큰" 요청
+    private String getAccessToken(String code) {
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(body, headers);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        // HTTP 응답 (JSON) -> 액세스 토큰 파싱
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = null;
+        try {
+            jsonNode = objectMapper.readTree(responseBody);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        return jsonNode.get("access_token").asText();
+    }
+
+    //토큰으로 카카오 API 호출
+    private LoginResponse getKakaoUserInfo(String accessToken) {
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> kakaoUserInfoRequest = new HttpEntity<>(headers);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                kakaoUserInfoRequest,
+                String.class
+        );
+
+        // responseBody에 있는 정보를 꺼냄
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = null;
+        try {
+            jsonNode = objectMapper.readTree(responseBody);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        Long id = jsonNode.get("id").asLong();
+        String email = jsonNode.get("kakao_account").get("email").asText();
+        String nickname = jsonNode.get("properties")
+                .get("nickname").asText();
+
+        return new LoginResponse(id, nickname, email);
+    }
+
+    // 카카오ID로 회원가입 처리
+    private User registerKakaoUserIfNeed(LoginResponse kakaoUserInfo) {
+        // DB 에 중복된 email이 있는지 확인
+        Long kakaoId=kakaoUserInfo.getId();
+        String kakaoEmail = kakaoUserInfo.getEmail();
+        String nickName = kakaoUserInfo.getNickname();
+        User kakaoUser = userRepository.findByEmail(kakaoEmail)
+                .orElse(null);
+
+        // 회원가입
+        if (kakaoUser == null) {
+            kakaoUser = new User(kakaoId, nickName, kakaoEmail);
+            userRepository.save(kakaoUser);
+        }
+
+        return kakaoUser;
+    }
+    
+}


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- 신규 피처 (카카오 로그인 관련 코드 생성)
카카오 로그인 API와 jwt 토큰 코드 생성했습니다!

## 💁 무엇이 어떻게 바뀌나요?
1. 카카오 로그인 API 만들었습니다!
2. 회원 정보 domain, dto, repository, service, controller **파일 생성**했습니다!
3. JWT 인증 관련 클래스들을 모으면 좋을 것 같아서 **Auth 패키지**를 새로 만들었습니다!
4. user테이블에서 PK인 uid속성을 auto increment 생성에서 카카오ID로 직접 생성으로 변경했고, **INT에서 BIGINT로 변경**하였습니다~!

## 📆 작업 예정인 것이 있나요 ?

- 북마크 API 코드 작성해두었는데 develop으로 머지 후 바로 파일 추가할 예정
- develop으로 머지 후 ErrorResponse 와 Handler 활용하기

## 💬 리뷰어분들께
- `application.properties` 파일에서 카카오 로그인 관련 필요한 id와 key값들은 **노션 백엔드 개발** 페이지에 추가해두었습니다!
- `Redirect URI`는 localhost와 posepicker.site 도메인 모두 추가해두었습니다! (노션 확인 가능)
- 제가 이 branch를 수경님 코드가 develop에 머지 되기 전에 만들어서 아직 코드 컨벤션 파일과 설정이 없어서 아마 적용이 안됐을꺼에요..!! (develop에 합치면 저절로 수정이 되는걸까요…? 만약 자동이 아니면 제가 수정해서 다시 올리도록 하겠습니다!) 
- User 도메인에서 BaseEntity를 상속하려고 했는데 DB 저장 과정에서 
```bash
not-null property references a null or transient value : com.dndoz.PosePicker.Domain.User.createdAt; nested exception is
```
이 오류가 발생해서 extends는 뺐습니다..! (생성시간을 추가 안하고 저장하려니 null 오류가 나는 것 같아요...) 따로 BaseEntity를 상속 안해도 괜찮을까요?!

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, design, refactor, test, add, set, docs, chore
-->
