### PR TITLE
fix: 포즈 필터링 중복 데이터 방지

### DIFF
--- a/src/main/java/com/dndoz/PosePicker/Dto/PoseFeedRequest.java
+++ b/src/main/java/com/dndoz/PosePicker/Dto/PoseFeedRequest.java
@@ -5,7 +5,7 @@ import io.swagger.annotations.ApiModel;
 @ApiModel(value = "포즈 피드 리스트 응답: PoseFeedRequest")
 public class PoseFeedRequest {
 	private Integer pageNumber = 0;
-	private Integer pageSize = 20;
+	private Integer pageSize = 8;
 	private Long peopleCount = 0L;
 	private Long frameCount = 0L;
 	private String tags;

--- a/src/main/java/com/dndoz/PosePicker/Repository/PoseFilterRepositoryCustom.java
+++ b/src/main/java/com/dndoz/PosePicker/Repository/PoseFilterRepositoryCustom.java
@@ -1,22 +1,21 @@
 package com.dndoz.PosePicker.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 
 import com.dndoz.PosePicker.Domain.PoseInfo;
 
 public interface PoseFilterRepositoryCustom {
-
 	Optional<PoseInfo> findByPoseId(Long pose_id);
 
 	Optional<PoseInfo> findRandomPoseInfo(Long people_count);
 
 	Boolean getRecommendationCheck(Long people_count, Long frame_count, String tags);
 
-	Slice<PoseInfo> findByFilter(Pageable pageable, Long people_count, Long frame_count, String tags);
+	List<PoseInfo> findByFilter(Pageable pageable, Long people_count, Long frame_count, String tags);
 
-	Slice<PoseInfo> getRecommendedContents(Pageable pageable);
+	List<PoseInfo> getRecommendedContents(Pageable pageable);
 
 }


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 포즈 필터링 중복 데이터 수정 사항 반영

## 💁 무엇이 어떻게 바뀌나요?

1. 페이지 스크롤 범위 8개 데이터로 추렸습니다!
2. 기존에 데이터 전체 가져올 때 랜덤으로 안보여지던 부분 랜덤 디스플레이로 바꿨습니다.
3. 페이지 네이션 적용시 이전 데이터 중복 필터링 안되던 이슈 해결했씁니다~!

## 📆 작업 예정인 것이 있나요 ?

- 

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, design, refactor, test, add, set, docs, chore
-->
