### PR TITLE
fix : 포즈 태그 정제

### DIFF
--- a/src/main/java/com/dndoz/PosePicker/Repository/PoseTagAttributeRepository.java
+++ b/src/main/java/com/dndoz/PosePicker/Repository/PoseTagAttributeRepository.java
@@ -9,7 +9,7 @@ import com.dndoz.PosePicker.Domain.PoseTagAttribute;
 
 public interface PoseTagAttributeRepository extends JpaRepository<PoseTagAttribute, Long> {
 
-	@Query(value = "SELECT * FROM tag_attribute LIMIT 9", nativeQuery = true)
+	@Query(value = "SELECT * FROM tag_attribute LIMIT 10 OFFSET 1", nativeQuery = true)
 	List<PoseTagAttribute> findPoseTagAttribute();
 
 }


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
포즈 태그 기존 정보 10개로 확장 & 추가

- 신규 피처

## 💁 무엇이 어떻게 바뀌나요?

1. 기존에 중복 의미로 존재하던 태그 `혼자` | `단독` 태그 중 `단독`만 남겼습니다.
2.  기존에 9개만 보여주던 태그 정보를 10개로 확장했습니다.

## 📆 작업 예정인 것이 있나요 ?

- 

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, design, refactor, test, add, set, docs, chore
-->
