### PR TITLE
fix: 필터링 시 북마크 여부 체크 오류 수정

### DIFF
--- a/src/main/java/com/dndoz/PosePicker/Auth/AuthTokensGenerator.java
+++ b/src/main/java/com/dndoz/PosePicker/Auth/AuthTokensGenerator.java
@@ -9,7 +9,7 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class AuthTokensGenerator {
     private static final String BEARER_TYPE = "Bearer";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60;            // 60분
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;           // 60분->임시 1주일
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;  // 14일
 	private static final long POSE_PICKER_TOKEN_EXPIRE_TIME = 1000 * 60 * 3; //3분
 

--- a/src/main/java/com/dndoz/PosePicker/Auth/AuthTokensGenerator.java
+++ b/src/main/java/com/dndoz/PosePicker/Auth/AuthTokensGenerator.java
@@ -9,9 +9,9 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class AuthTokensGenerator {
     private static final String BEARER_TYPE = "Bearer";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60;            // 60분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;  // 14일
-	private static final long POSE_PICKER_TOKEN_EXPIRE_TIME = 1000 * 60; //1분
+	private static final long POSE_PICKER_TOKEN_EXPIRE_TIME = 1000 * 60 * 3; //3분
 
     private final JwtTokenProvider jwtTokenProvider;
 	private final PPJwtTokenProvider ppJwtTokenProvider;

--- a/src/main/java/com/dndoz/PosePicker/Auth/JwtTokenProvider.java
+++ b/src/main/java/com/dndoz/PosePicker/Auth/JwtTokenProvider.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Component;
 import java.security.Key;
 import java.util.Date;
 
-
 @Component
 public class JwtTokenProvider {
 	private final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -61,18 +60,26 @@ public class JwtTokenProvider {
 	}
 
 	//유효한 토큰인지 확인
-	public boolean validateToken(String token) {
+	public boolean validateToken(String token) throws IllegalAccessException{
 		try {
 			Jws<Claims> claims = Jwts.parser().setSigningKey(key).parseClaimsJws(token);
 			return !claims.getBody().getExpiration().before(new Date());
 		} catch (ExpiredJwtException e) {
 			// 토큰이 만료된 경우
 			logger.error("Expired JWT token: {}", e.getMessage());
-			return false;
-		} catch (UnsupportedJwtException | MalformedJwtException | IllegalArgumentException e) {
-			// 지원되지 않는 토큰, 형식이 잘못된 토큰, 서명 검증 실패 등의 예외
+			throw e;
+		} catch (UnsupportedJwtException e) {
+			// 지원되지 않는 토큰
+			logger.error("Unsupported JWT token: {}", e.getMessage());
+			throw e;
+		} catch (MalformedJwtException e) {
+			// 잘못된 jwt 구조 토큰
+			logger.error("Malformed JWT token: {}", e.getMessage());
+			throw e;
+		} catch (Exception e) {
 			logger.error("Invalid JWT token: {}", e.getMessage());
-			return false;
+			//throw new IllegalAccessException("유효한 토큰이 아닙니다.");
+			throw e;
 		}
 	}
 

--- a/src/main/java/com/dndoz/PosePicker/Auth/PPJwtTokenProvider.java
+++ b/src/main/java/com/dndoz/PosePicker/Auth/PPJwtTokenProvider.java
@@ -3,19 +3,24 @@ package com.dndoz.PosePicker.Auth;
 import java.security.Key;
 import java.util.Date;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 
 @Component
 public class PPJwtTokenProvider {
-
+	private final Logger logger = LoggerFactory.getLogger(this.getClass());
 	private final Key pz_key;
 
 	public PPJwtTokenProvider(@Value("${custom.jwt.posepickerKey}") String secretKey) {
@@ -47,4 +52,29 @@ public class PPJwtTokenProvider {
 			return e.getClaims();
 		}
 	}
+
+	//유효한 토큰인지 확인
+	public boolean validateToken(String token) throws IllegalAccessException{
+		try {
+			Jws<Claims> claims = Jwts.parser().setSigningKey(pz_key).parseClaimsJws(token);
+			return !claims.getBody().getExpiration().before(new Date());
+		} catch (ExpiredJwtException e) {
+			// 토큰이 만료된 경우
+			logger.error("Expired JWT token: {}", e.getMessage());
+			throw e;
+		} catch (UnsupportedJwtException e) {
+			// 지원되지 않는 토큰
+			logger.error("Unsupported JWT token: {}", e.getMessage());
+			throw e;
+		} catch (MalformedJwtException e) {
+			// 잘못된 jwt 구조 토큰
+			logger.error("Malformed JWT token: {}", e.getMessage());
+			throw e;
+		} catch (Exception e) {
+			logger.error("Invalid JWT token: {}", e.getMessage());
+			//throw new IllegalAccessException("유효한 토큰이 아닙니다.");
+			throw e;
+		}
+	}
+
 }

--- a/src/main/java/com/dndoz/PosePicker/Config/SwaggerConfig.java
+++ b/src/main/java/com/dndoz/PosePicker/Config/SwaggerConfig.java
@@ -1,5 +1,7 @@
 package com.dndoz.PosePicker.Config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -7,11 +9,16 @@ import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 
 @Configuration
 public class SwaggerConfig {
+
 	@Bean
 	public Docket api() {
 		return new Docket(DocumentationType.OAS_30)
@@ -19,7 +26,10 @@ public class SwaggerConfig {
 			.select()
 			.apis(RequestHandlerSelectors.basePackage("com.dndoz.PosePicker"))
 			.paths(PathSelectors.any())
-			.build();
+			.build()
+			.securityContexts(List.of(this.securityContext())) // SecurityContext 설정
+			.securitySchemes(List.of(this.apiKey())) // ApiKey 설정
+			;
 	}
 
 	private ApiInfo apiInfo() {
@@ -28,5 +38,24 @@ public class SwaggerConfig {
 			.version("0.0.1")
 			.description("Pose Picker swagger api")
 			.build();
+	}
+
+	// JWT SecurityContext 구성
+	private SecurityContext securityContext() {
+		return SecurityContext.builder()
+			.securityReferences(defaultAuth())
+			.build();
+	}
+
+	private List<SecurityReference> defaultAuth() {
+		AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+		AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+		authorizationScopes[0] = authorizationScope;
+		return List.of(new SecurityReference("Authorization", authorizationScopes));
+	}
+
+	// ApiKey 정의
+	private ApiKey apiKey() {
+		return new ApiKey("Authorization", "Authorization", "header");
 	}
 }

--- a/src/main/java/com/dndoz/PosePicker/Controller/PoseController.java
+++ b/src/main/java/com/dndoz/PosePicker/Controller/PoseController.java
@@ -49,9 +49,11 @@ public class PoseController {
 	@ApiResponses({@ApiResponse(code = 200, message = "포즈 사진 상세 조회 성공"),
 		@ApiResponse(code = 401, message = "접근 권한이 없습니다.")})
 	@ApiOperation(value = "포즈 사진 상세 조회", notes = "사진 클릭 시 포즈 상세 정보")
-	public ResponseEntity<PoseInfoResponse> getPoseInfo(@PathVariable Long pose_id) {
+	public ResponseEntity<PoseInfoResponse> getPoseInfo(
+		@RequestHeader(value = "Authorization", required = false) String accessToken, @PathVariable Long pose_id) throws
+		IllegalAccessException {
 		logger.info("[getPoseInfo] 포즈 사진 상세 조회 요청");
-		return ResponseEntity.ok(poseService.getPoseInfo(pose_id));
+		return ResponseEntity.ok(poseService.getPoseInfo(accessToken,pose_id));
 	}
 
 	/**

--- a/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
+++ b/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.NoSuchElementException;
+import javax.servlet.http.HttpServletRequest;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,9 +31,11 @@ public class UserController {
     @ResponseBody
     @GetMapping("/login/oauth/kakao")
 	@ApiOperation(value = "웹 카카오 로그인", notes = "웹 프론트 버전 카카오 로그인")
-    public ResponseEntity<LoginResponse> kakaoLogin(@RequestParam String code){
+    public ResponseEntity<LoginResponse> kakaoLogin(@RequestParam String code, HttpServletRequest request){
         try{
-            return ResponseEntity.ok(kakaoService.kakaoLogin(code));
+			// 현재 도메인 확인
+			String currentDomain = request.getServerName();
+            return ResponseEntity.ok(kakaoService.kakaoLogin(code, currentDomain));
         } catch (NoSuchElementException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND,"Item Not Found");
         }

--- a/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
+++ b/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
@@ -52,7 +52,7 @@ public class UserController {
 	public ResponseEntity<LoginResponse> iosKakaoLogin(@RequestBody KakaoLoginRequest loginRequest){
 		try{
 			return ResponseEntity.ok(kakaoService.iosKakaoLogin(loginRequest));
-		} catch (NoSuchElementException e) {
+		} catch (NoSuchElementException | IllegalAccessException e) {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND,"Exception");
 		}
 	}

--- a/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
+++ b/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
@@ -3,6 +3,7 @@ package com.dndoz.PosePicker.Controller;
 import com.dndoz.PosePicker.Dto.KakaoLoginRequest;
 import com.dndoz.PosePicker.Dto.LoginResponse;
 import com.dndoz.PosePicker.Dto.PPTokenResponse;
+import com.dndoz.PosePicker.Global.status.StatusResponse;
 import com.dndoz.PosePicker.Service.AppleService;
 import com.dndoz.PosePicker.Service.KakaoService;
 import io.swagger.annotations.Api;
@@ -57,12 +58,24 @@ public class UserController {
 	}
 
 	@ResponseBody
-	@GetMapping("/login/ios/apple/")
+	@GetMapping("/login/ios/apple")
 	@ApiOperation(value = "ios 애플 로그인", notes = "ios 버전 애플 로그인")
 	public ResponseEntity<LoginResponse> appleLogin(@RequestParam String idToken){
 		try{
 			return ResponseEntity.ok(appleService.appleLogin(idToken));
 		} catch (NoSuchElementException e) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND,"Item Not Found");
+		}
+	}
+
+	@ResponseBody
+	@DeleteMapping("/signOut")
+	@ApiOperation(value = "탈퇴하기", notes = "북마크 정보 삭제 후 회원 탈퇴")
+	public ResponseEntity<StatusResponse> signOut(
+		@RequestHeader(value= "Authorization", required=false) String accessToken){
+		try{
+			return ResponseEntity.ok(kakaoService.signOut(accessToken));
+		} catch (NoSuchElementException | IllegalAccessException e) {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND,"Item Not Found");
 		}
 	}

--- a/src/main/java/com/dndoz/PosePicker/Domain/PoseInfo.java
+++ b/src/main/java/com/dndoz/PosePicker/Domain/PoseInfo.java
@@ -8,7 +8,6 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
-import com.dndoz.PosePicker.Dto.PoseInfoAndBookmarkResponse;
 import com.dndoz.PosePicker.Global.entity.BaseEntity;
 
 import io.swagger.annotations.ApiModel;
@@ -55,17 +54,18 @@ public class PoseInfo extends BaseEntity {
 		this.tagAttributes = tagAttributes;
 	}
 
-	// public PoseInfo(PoseInfo poseInfo, String tagAttributes, Boolean bookmarkCheck) {
-	// 	this.poseId = poseInfo.getPoseId();
-	// 	this.imageKey = poseInfo.getImageKey();
-	// 	this.source = poseInfo.getSource();
-	// 	this.sourceUrl = poseInfo.getSourceUrl();
-	// 	this.poseId = poseInfo.getPoseId();
-	// 	this.peopleCount = poseInfo.getPeopleCount();
-	// 	this.frameCount = poseInfo.getFrameCount();
-	// 	this.tagAttributes = tagAttributes;
-	// 	this.bookmarkCheck=bookmarkCheck;
-	// }
+	//포즈피드 필터링 시 북마크 여부 포함한 PoseInfo
+	public PoseInfo(PoseInfo poseInfo, String tagAttributes, Boolean bookmarkCheck) {
+		this.poseId = poseInfo.getPoseId();
+		this.imageKey = poseInfo.getImageKey();
+		this.source = poseInfo.getSource();
+		this.sourceUrl = poseInfo.getSourceUrl();
+		this.poseId = poseInfo.getPoseId();
+		this.peopleCount = poseInfo.getPeopleCount();
+		this.frameCount = poseInfo.getFrameCount();
+		this.tagAttributes = tagAttributes;
+		this.bookmarkCheck=bookmarkCheck;
+	}
 
 	public Long getPoseId() {
 		return poseId;

--- a/src/main/java/com/dndoz/PosePicker/Global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/dndoz/PosePicker/Global/error/GlobalExceptionHandler.java
@@ -16,9 +16,11 @@ import org.springframework.web.multipart.MultipartException;
 
 import com.dndoz.PosePicker.Global.error.exception.BusinessException;
 import com.dndoz.PosePicker.Global.error.exception.ErrorCode;
-import com.dndoz.PosePicker.Global.status.StatusCode;
-import com.dndoz.PosePicker.Global.status.StatusResponse;
 
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import lombok.extern.slf4j.Slf4j;
 
 @ControllerAdvice
@@ -113,4 +115,34 @@ public class GlobalExceptionHandler {
         final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
+
+    //JWT 토큰 에러 추가
+	@ExceptionHandler(UnsupportedJwtException.class)
+	public ResponseEntity<ErrorResponse> UnsupportedJwtException(Exception e) {
+		e.printStackTrace();
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.UNSUPPORTED_JWT_TOKEN);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(MalformedJwtException.class)
+	public ResponseEntity<ErrorResponse> MalformedJwtException(Exception e) {
+		e.printStackTrace();
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.MALFORMED_JWT_TOKEN);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(ExpiredJwtException.class)
+	public ResponseEntity<ErrorResponse> ExpiredJwtException(Exception e) {
+		e.printStackTrace();
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.EXPIRED_JWT_TOKEN);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(IllegalAccessException.class)
+	public ResponseEntity<ErrorResponse> IllegalAccessException(Exception e) {
+		e.printStackTrace();
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.UNAUTHORIZED_JWT_TOKEN);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
 }

--- a/src/main/java/com/dndoz/PosePicker/Global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/dndoz/PosePicker/Global/error/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartException;
 
+import com.dndoz.PosePicker.Global.error.exception.BookmarkException;
 import com.dndoz.PosePicker.Global.error.exception.BusinessException;
 import com.dndoz.PosePicker.Global.error.exception.ErrorCode;
 
@@ -121,28 +122,34 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorResponse> UnsupportedJwtException(Exception e) {
 		e.printStackTrace();
 		final ErrorResponse response = ErrorResponse.of(ErrorCode.UNSUPPORTED_JWT_TOKEN);
-		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+		return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
 	}
 
 	@ExceptionHandler(MalformedJwtException.class)
 	public ResponseEntity<ErrorResponse> MalformedJwtException(Exception e) {
 		e.printStackTrace();
 		final ErrorResponse response = ErrorResponse.of(ErrorCode.MALFORMED_JWT_TOKEN);
-		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+		return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
 	}
 
 	@ExceptionHandler(ExpiredJwtException.class)
 	public ResponseEntity<ErrorResponse> ExpiredJwtException(Exception e) {
 		e.printStackTrace();
 		final ErrorResponse response = ErrorResponse.of(ErrorCode.EXPIRED_JWT_TOKEN);
-		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+		return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
 	}
 
 	@ExceptionHandler(IllegalAccessException.class)
 	public ResponseEntity<ErrorResponse> IllegalAccessException(Exception e) {
 		e.printStackTrace();
 		final ErrorResponse response = ErrorResponse.of(ErrorCode.UNAUTHORIZED_JWT_TOKEN);
-		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+		return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
 	}
 
+	//북마크 에러
+	@ExceptionHandler(BookmarkException.class)
+	public ResponseEntity<ErrorResponse> handleBookmarkException(BookmarkException e) {
+		final ErrorResponse response = ErrorResponse.of(ErrorCode.BOOKMARK_BAD_REQUEST);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
 }

--- a/src/main/java/com/dndoz/PosePicker/Global/error/exception/BookmarkException.java
+++ b/src/main/java/com/dndoz/PosePicker/Global/error/exception/BookmarkException.java
@@ -1,0 +1,14 @@
+package com.dndoz.PosePicker.Global.error.exception;
+
+public class BookmarkException extends RuntimeException{
+	private ErrorCode errorCode;
+
+	public BookmarkException(String message, ErrorCode errorCode) {
+		super(message);
+		this.errorCode = errorCode;
+	}
+
+	public BookmarkException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/dndoz/PosePicker/Global/error/exception/ErrorCode.java
+++ b/src/main/java/com/dndoz/PosePicker/Global/error/exception/ErrorCode.java
@@ -14,11 +14,14 @@ public enum ErrorCode {
     BAD_REQUEST(400, "C007", " Bad Request"),
     UNSUPPORTED_MEDIA_TYPE(415, "C008", "UNSUPPORTED_MEDIA_TYPE"),
     FILE_SIZE_EXCEED(416, "C009", "REQUESTED_RANGE_NOT_SATISFIABLE"),
-    EXPECTATION_FAILED(417, "C010", "EXPECTATION_FAILED")
+    EXPECTATION_FAILED(417, "C010", "EXPECTATION_FAILED"),
+	//JWT 토큰 ErrorCode
+	UNSUPPORTED_JWT_TOKEN(401,"C011","UnsupportedJwtException 지원되지 않는 토큰"),
+	MALFORMED_JWT_TOKEN(402,"C012","MalformedJwtException 잘못된 jwt 구조"),
+	EXPIRED_JWT_TOKEN(403,"C013","ExpiredJwtException 토큰 만료"),
+	UNAUTHORIZED_JWT_TOKEN(401,"C014","Unauthorized")
+	;
 
-
-
-    ;
     private final String code;
     private final String message;
     private int status;
@@ -40,6 +43,4 @@ public enum ErrorCode {
     public int getStatus() {
         return status;
     }
-
-
 }

--- a/src/main/java/com/dndoz/PosePicker/Global/error/exception/ErrorCode.java
+++ b/src/main/java/com/dndoz/PosePicker/Global/error/exception/ErrorCode.java
@@ -17,10 +17,13 @@ public enum ErrorCode {
     EXPECTATION_FAILED(417, "C010", "EXPECTATION_FAILED"),
 	//JWT 토큰 ErrorCode
 	UNSUPPORTED_JWT_TOKEN(401,"C011","UnsupportedJwtException 지원되지 않는 토큰"),
-	MALFORMED_JWT_TOKEN(402,"C012","MalformedJwtException 잘못된 jwt 구조"),
-	EXPIRED_JWT_TOKEN(403,"C013","ExpiredJwtException 토큰 만료"),
-	UNAUTHORIZED_JWT_TOKEN(401,"C014","Unauthorized")
+	MALFORMED_JWT_TOKEN(401,"C012","MalformedJwtException 잘못된 jwt 구조"),
+	EXPIRED_JWT_TOKEN(401,"C013","ExpiredJwtException 토큰 만료"),
+	UNAUTHORIZED_JWT_TOKEN(401,"C014","Unauthorized"),
+
+	BOOKMARK_BAD_REQUEST(400,"C015","북마크 API 잘못된 요청")
 	;
+
 
     private final String code;
     private final String message;

--- a/src/main/java/com/dndoz/PosePicker/Global/status/StatusResponse.java
+++ b/src/main/java/com/dndoz/PosePicker/Global/status/StatusResponse.java
@@ -2,6 +2,8 @@ package com.dndoz.PosePicker.Global.status;
 
 import java.net.URI;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
@@ -11,6 +13,7 @@ import lombok.NoArgsConstructor;
 
 @ApiModel(value = "모델 태그 정보")
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL) // Null 값인 필드 제외하고 보내기
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class StatusResponse {

--- a/src/main/java/com/dndoz/PosePicker/Repository/BookmarkRepository.java
+++ b/src/main/java/com/dndoz/PosePicker/Repository/BookmarkRepository.java
@@ -13,4 +13,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark,Long> {
 	Optional<Boolean> findByUserAndPoseInfo(User user, PoseInfo poseInfo);
 	//북마크 삭제
 	void deleteByUserAndPoseInfo(User user, PoseInfo poseInfo);
+	//회원탈퇴 시, 북마크 정보 삭제
+	void deleteByUser(User user);
 }

--- a/src/main/java/com/dndoz/PosePicker/Repository/BookmarkRepository.java
+++ b/src/main/java/com/dndoz/PosePicker/Repository/BookmarkRepository.java
@@ -1,8 +1,11 @@
 package com.dndoz.PosePicker.Repository;
 
+import java.math.BigInteger;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.dndoz.PosePicker.Domain.Bookmark;
 import com.dndoz.PosePicker.Domain.PoseInfo;
@@ -11,8 +14,14 @@ import com.dndoz.PosePicker.Domain.User;
 public interface BookmarkRepository extends JpaRepository<Bookmark,Long> {
 	//북마크 여부 확인
 	Optional<Boolean> findByUserAndPoseInfo(User user, PoseInfo poseInfo);
+
+	//북마크 여부 확인
+	@Query(value="SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END as bookmarkCheck FROM bookmark b WHERE b.uid = :userId AND b.pose_id = :poseId", nativeQuery = true)
+	BigInteger existsByUserIdAndPoseId(@Param("userId") Long userId, @Param("poseId") Long poseId);
+
 	//북마크 삭제
 	void deleteByUserAndPoseInfo(User user, PoseInfo poseInfo);
+
 	//회원탈퇴 시, 북마크 정보 삭제
 	void deleteByUser(User user);
 }

--- a/src/main/java/com/dndoz/PosePicker/Repository/PoseFilterRepositoryCustom.java
+++ b/src/main/java/com/dndoz/PosePicker/Repository/PoseFilterRepositoryCustom.java
@@ -14,9 +14,9 @@ public interface PoseFilterRepositoryCustom {
 
 	Boolean getRecommendationCheck(Long people_count, Long frame_count, String tags);
 
-	List<PoseInfo> findByFilter(Pageable pageable, Long people_count, Long frame_count, String tags);
+	List<PoseInfo> findByFilter(Pageable pageable, Long people_count, Long frame_count, String tags, Long userId);
 
-	List<PoseInfo> findByFilterNoTag(Pageable pageable, Long people_count, Long frame_count);
+	List<PoseInfo> findByFilterNoTag(Pageable pageable, Long people_count, Long frame_count, Long userId);
 
 	List<PoseInfo> getRecommendedContents(Pageable pageable);
 

--- a/src/main/java/com/dndoz/PosePicker/Repository/PoseFilterRepositoryImpl.java
+++ b/src/main/java/com/dndoz/PosePicker/Repository/PoseFilterRepositoryImpl.java
@@ -37,7 +37,7 @@ public class PoseFilterRepositoryImpl implements PoseFilterRepositoryCustom {
 			.leftJoin(qPoseTagAttribute).on(qPoseTag.poseTagAttribute.attributeId.eq(qPoseTagAttribute.attributeId))
 			.where(qPoseInfo.poseId.eq(pose_id))
 			.groupBy(qPoseInfo.poseId)
-			.fetchOne();
+			.fetchOne();	//poseId 고유한 결과-> fetchOne
 
 		List<String> attributes = queryFactory.select(qPoseTagAttribute.attribute)
 			.from(qPoseTag)
@@ -65,7 +65,7 @@ public class PoseFilterRepositoryImpl implements PoseFilterRepositoryCustom {
 				eqPeopleCount(qPoseInfo, people_count)
 			)
 			.orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
-			.fetchFirst();
+			.fetchFirst();	//랜덤 첫번째 결과-> fetchFirst
 
 		List<String> attributes = queryFactory.select(qPoseTagAttribute.attribute)
 			.from(qPoseTag)

--- a/src/main/java/com/dndoz/PosePicker/Service/AppleService.java
+++ b/src/main/java/com/dndoz/PosePicker/Service/AppleService.java
@@ -133,10 +133,11 @@ public class AppleService {
 			userRepository.save(appleUser);
 
 			//토큰 생성
-			AuthTokens token=authTokensGenerator.generate(appleEmail);
+			AuthTokens token=authTokensGenerator.generate(iosId);
 			return new LoginResponse(uid,nickName,appleEmail,token);
 		} else { // 로그인
-			AuthTokens token=authTokensGenerator.generate(appleEmail);
+			iosId= String.valueOf(appleUser.getUid());
+			AuthTokens token=authTokensGenerator.generate(iosId);
 			return new LoginResponse(appleUser.getUid(),nickName,appleEmail,token);
 		}
 	}

--- a/src/main/java/com/dndoz/PosePicker/Service/BookmarkService.java
+++ b/src/main/java/com/dndoz/PosePicker/Service/BookmarkService.java
@@ -33,13 +33,11 @@ public class BookmarkService{
 
 	//북마크 등록
 	@Transactional
-	public BookmarkResponse insert(String accessToken, Long poseId) throws Exception {
+	public BookmarkResponse insert(String accessToken, Long poseId) throws Exception{
 		String token=jwtTokenProvider.extractJwtToken(accessToken);
-		//System.out.println("@@@@@@@Bookmark 39행 accesstoken:" + token);
 		if (! jwtTokenProvider.validateToken(token)) {
-			throw new IllegalAccessException("유효한 토큰이 아닙니다.");
+			return null;
 		}
-
 		Long userId= Long.valueOf(jwtTokenProvider.extractUid(token));
 		User user=userRepository.findById(userId).orElseThrow(NullPointerException::new);
 		PoseInfo poseInfo = poseInfoRepository.findByPoseId(poseId).orElseThrow(NullPointerException::new);
@@ -63,9 +61,8 @@ public class BookmarkService{
 	public BookmarkResponse delete(String accessToken, Long poseId) throws Exception {
 		String token=jwtTokenProvider.extractJwtToken(accessToken);
 		if (! jwtTokenProvider.validateToken(token)) {
-			throw new IllegalAccessException("유효한 토큰이 아닙니다.");
+			return null;
 		}
-
 		Long userId= Long.valueOf(jwtTokenProvider.extractUid(token));
 		User user=userRepository.findById(userId).orElseThrow(NullPointerException::new);
 		PoseInfo poseInfo = poseInfoRepository.findByPoseId(poseId).orElseThrow(NullPointerException::new);
@@ -84,11 +81,11 @@ public class BookmarkService{
 
 	// 북마크 피드 리스트 스크롤
 	@Transactional(readOnly = true)
-	public Slice<PoseInfoResponse> findBookmark(String accessToken, final Integer pageNumber, final Integer pageSize) throws
-		IllegalAccessException {
+	public Slice<PoseInfoResponse> findBookmark(String accessToken, final Integer pageNumber, final Integer pageSize)
+		throws IllegalAccessException {
 		String token=jwtTokenProvider.extractJwtToken(accessToken);
 		if (! jwtTokenProvider.validateToken(token)) {
-			throw new IllegalAccessException("유효한 토큰이 아닙니다.");
+			return null;
 		}
 		Long uid= Long.valueOf(jwtTokenProvider.extractUid(token));
 		Pageable pageable = PageRequest.of(pageNumber, pageSize);

--- a/src/main/java/com/dndoz/PosePicker/Service/BookmarkService.java
+++ b/src/main/java/com/dndoz/PosePicker/Service/BookmarkService.java
@@ -13,6 +13,7 @@ import com.dndoz.PosePicker.Domain.PoseInfo;
 import com.dndoz.PosePicker.Domain.User;
 import com.dndoz.PosePicker.Dto.BookmarkResponse;
 import com.dndoz.PosePicker.Dto.PoseInfoResponse;
+import com.dndoz.PosePicker.Global.error.exception.BookmarkException;
 import com.dndoz.PosePicker.Repository.BookmarkRepository;
 import com.dndoz.PosePicker.Repository.PoseInfoRepository;
 import com.dndoz.PosePicker.Repository.UserRepository;
@@ -51,7 +52,7 @@ public class BookmarkService{
 			response.setPoseId(poseInfo.getPoseId());
 			return response;
 		}else{
-			throw new Exception();
+			throw new BookmarkException("Bookmark already exists for the user and poseInfo");
 		}
 	}
 
@@ -75,7 +76,7 @@ public class BookmarkService{
 			response.setPoseId(-1L);
 			return response;
 		} else{
-			throw new Exception();
+			throw new BookmarkException("Bookmark doesn't exists for the user and poseInfo");
 		}
 	}
 

--- a/src/main/java/com/dndoz/PosePicker/Service/KakaoService.java
+++ b/src/main/java/com/dndoz/PosePicker/Service/KakaoService.java
@@ -3,6 +3,7 @@ package com.dndoz.PosePicker.Service;
 import com.dndoz.PosePicker.Auth.AuthTokens;
 import com.dndoz.PosePicker.Auth.AuthTokensGenerator;
 import com.dndoz.PosePicker.Auth.JwtTokenProvider;
+import com.dndoz.PosePicker.Auth.PPJwtTokenProvider;
 import com.dndoz.PosePicker.Domain.User;
 import com.dndoz.PosePicker.Dto.KakaoLoginRequest;
 import com.dndoz.PosePicker.Dto.LoginResponse;
@@ -35,6 +36,7 @@ public class KakaoService {
     private final UserRepository userRepository;
     private final AuthTokensGenerator authTokensGenerator;
 	private final JwtTokenProvider jwtTokenProvider;
+	private final PPJwtTokenProvider psJwTokenProvider;
 	private final BookmarkRepository bookmarkRepository;
 
 	/** [1] ios 버전 카카오 로그인 **/
@@ -46,14 +48,16 @@ public class KakaoService {
 		return tokenDto;
 	}
 
-	public LoginResponse iosKakaoLogin(KakaoLoginRequest loginRequest) {
+	public LoginResponse iosKakaoLogin(KakaoLoginRequest loginRequest) throws IllegalAccessException {
 		Long uid=loginRequest.getUid();
 		String email= loginRequest.getEmail();
 		String subject= authTokensGenerator.extractSubject(loginRequest.getToken());
 
 		if (subject.equals("posePickerLogin")){
-			User kakaoUser = userRepository.findById(loginRequest.getUid())
-				.orElse(null);
+			if (! psJwTokenProvider.validateToken(loginRequest.getToken())) {
+				return null;
+			}
+			User kakaoUser = userRepository.findById(loginRequest.getUid()).orElse(null);
 
 			if (kakaoUser == null) {    //회원가입
 				kakaoUser= new User();
@@ -70,7 +74,6 @@ public class KakaoService {
 		}else{
 			return null;
 		}
-
 	}
 
 	/** [2] Web 버전 카카오 로그인 **/

--- a/src/main/java/com/dndoz/PosePicker/Service/KakaoService.java
+++ b/src/main/java/com/dndoz/PosePicker/Service/KakaoService.java
@@ -18,6 +18,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -33,7 +35,9 @@ import java.util.HashMap;
 @Service
 @RequiredArgsConstructor
 public class KakaoService {
-    private final UserRepository userRepository;
+	private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+	private final UserRepository userRepository;
     private final AuthTokensGenerator authTokensGenerator;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final PPJwtTokenProvider psJwTokenProvider;
@@ -77,9 +81,12 @@ public class KakaoService {
 	}
 
 	/** [2] Web 버전 카카오 로그인 **/
-    public LoginResponse kakaoLogin(String code) {
+    public LoginResponse kakaoLogin(String code, String currentDomain) {
+    	//0. 동적으로 redirect URI 선택
+		String redirectUri=selectRedirectUri(currentDomain);
+
         // 1. "인가 코드"로 "액세스 토큰" 요청
-        String accessToken = getAccessToken(code);
+        String accessToken = getAccessToken(code, redirectUri);
 
         // 2. 토큰으로 카카오 API 호출
         HashMap<String, Object> userInfo= getKakaoUserInfo(accessToken);
@@ -92,11 +99,32 @@ public class KakaoService {
 
     @Value("${kakao.key.client-id}")
     private String clientId;
-    @Value("${kakao.redirect-uri}")
-    private String redirectUri;
+	@Value("${kakao.redirect-uri.main}")
+	private String isFirstDomain;
+    @Value("${kakao.redirect-uri.develop}")
+    private String isSecondDomain;
+	@Value("${kakao.redirect-uri.local}")
+	private String isThirdDomain;
+
+	//0. 도메인에 따라 동적으로 redirect URI 선택
+	private String selectRedirectUri(String currentDomain) {
+		logger.info("[dynamicRedirectUri] 카카오 로그인 Uri 요청");
+		logger.info(currentDomain);
+		String dynamicRedirectUri = "";
+
+		if ("posepicker.site".equals(currentDomain)) {
+			dynamicRedirectUri=isFirstDomain;
+		} else if ("api-posepicker.site".equals(currentDomain)) {
+			dynamicRedirectUri=isSecondDomain;
+		} else if ("localhost".equals(currentDomain)){ //localhost
+			dynamicRedirectUri=isThirdDomain;
+		}
+		logger.info(dynamicRedirectUri);
+		return dynamicRedirectUri;
+	}
 
     //1. "인가 코드"로 "액세스 토큰" 요청
-    private String getAccessToken(String code) {
+    private String getAccessToken(String code, String redirectUri) {
 
         // HTTP Header 생성
         HttpHeaders headers = new HttpHeaders();
@@ -156,7 +184,6 @@ public class KakaoService {
         JsonNode jsonNode = null;
         try {
             jsonNode = objectMapper.readTree(responseBody);
-            //System.out.println(jsonNode);
         } catch (JsonProcessingException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/dndoz/PosePicker/Service/PoseService.java
+++ b/src/main/java/com/dndoz/PosePicker/Service/PoseService.java
@@ -97,7 +97,7 @@ public class PoseService {
 		if (null!=accessToken) {
 			String token=jwtTokenProvider.extractJwtToken(accessToken);
 			if (! jwtTokenProvider.validateToken(token)) {
-				throw new IllegalAccessException("유효한 토큰이 아닙니다.");
+				return null;
 			}
 			Long userId= Long.valueOf(jwtTokenProvider.extractUid(token));
 			setBookmarkStatusForPoses(userId);
@@ -111,7 +111,7 @@ public class PoseService {
 		if (null!=accessToken) {
 			String token=jwtTokenProvider.extractJwtToken(accessToken);
 			if (! jwtTokenProvider.validateToken(token)) {
-				throw new IllegalAccessException("유효한 토큰이 아닙니다.");
+				return null;
 			}
 			Long userId= Long.valueOf(jwtTokenProvider.extractUid(token));
 			setBookmarkStatusForPoses(userId);


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 북마크 여부 체크 추가 및 필터링 시 모두 false로 오는 오류 수정

## 💁 무엇이 어떻게 바뀌나요?

1. 세부페이지에서도 북마크 여부 적용되도록 추가했습니다!
2. 포즈피드 필터링 시에 북마크 여부 모두 false로 오는 오류 수정했습니다!
3. print 대신 logger로 모두 수정했습니다!

## 📆 작업 예정인 것이 있나요 ?

- 

## 💬 리뷰어분들께
- poseInfo 객체에 bookmarkCheck 속성을 같이 담아서 보내고,  **로그인을 안했으면 모두 false**. **로그인을 했으면 북마크여부에 따라 true/false.** 로 보내고 있습니다!
- 기존에는 Service에서 필터링 하기 전에 먼저 북마크 여부를 체크한 후 setBookmarkCheck(true) 했었는데 필터링 과정에서 랜덤으로 순서가 변경되다 보니 모두 false로 바꼈던 것 같아요....ㅠㅠ 그래서 queryDSL에서 북마크 여부 체크한 후에 poseInfo랑 북마크 여부값 넘겨주도록 했습니당! 

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, design, refactor, test, add, set, docs, chore
-->
