### PR TITLE
feat: 토큰 재발급 및 로그아웃

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     //feign client
     //implementation platform("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
     //implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
+
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dndoz/PosePicker/Auth/AuthTokensGenerator.java
+++ b/src/main/java/com/dndoz/PosePicker/Auth/AuthTokensGenerator.java
@@ -9,7 +9,7 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class AuthTokensGenerator {
     private static final String BEARER_TYPE = "Bearer";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;           // 60분->임시 1주일
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60;           //1시간
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;  // 14일
 	private static final long POSE_PICKER_TOKEN_EXPIRE_TIME = 1000 * 60 * 3; //3분
 
@@ -24,7 +24,7 @@ public class AuthTokensGenerator {
 
         //String subject = email.toString();
         String accessToken = jwtTokenProvider.accessTokenGenerate(uid, accessTokenExpiredAt);
-        String refreshToken = jwtTokenProvider.refreshTokenGenerate(refreshTokenExpiredAt);
+        String refreshToken = jwtTokenProvider.refreshTokenGenerate(uid, refreshTokenExpiredAt);
 
         return AuthTokens.of(accessToken, refreshToken, BEARER_TYPE, ACCESS_TOKEN_EXPIRE_TIME / 1000L);
     }

--- a/src/main/java/com/dndoz/PosePicker/Config/RedisConfig.java
+++ b/src/main/java/com/dndoz/PosePicker/Config/RedisConfig.java
@@ -1,0 +1,44 @@
+package com.dndoz.PosePicker.Config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Value("${redis.host}")
+	private String host;
+	@Value("${redis.port}")
+	private int port;
+	@Value("${redis.password}")
+	private String password;
+
+	//RedisTemplate을 이용한 방식 RedisConnectionFactory 인터페이스를 통해 LettuceConnectionFactory를 생성하여 반환
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+		redisConfiguration.setHostName(host);
+		redisConfiguration.setPort(port);
+		redisConfiguration.setPassword(password);
+		LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisConfiguration);
+		return lettuceConnectionFactory;
+	}
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate() {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>(); // redisTemplate를 받아와서 set, get, delete를 사용
+		redisTemplate.setKeySerializer(new StringRedisSerializer()); // redis-cli을 통해 직접 데이터를 조회 시 알아볼 수 없는 형태로 출력되는 것을 방지
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+		return redisTemplate;
+	}
+
+}

--- a/src/main/java/com/dndoz/PosePicker/Controller/AuthController.java
+++ b/src/main/java/com/dndoz/PosePicker/Controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.dndoz.PosePicker.Controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.dndoz.PosePicker.Auth.AuthTokens;
+import com.dndoz.PosePicker.Service.AuthService;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/auth")
+@Api(tags = {"토큰 재발급 API"})
+@RequiredArgsConstructor
+public class AuthController {
+	private final AuthService authService;
+
+	@PostMapping("/reissue-token")
+	@ApiOperation(value = "토큰 재발급", notes = "accessToken 만료 시 refreshToken 으로 재발급")
+	public ResponseEntity<AuthTokens> reissueToken(
+		@RequestHeader(value= "Authorization", required=false) String refreshToken) throws IllegalAccessException {
+		try {
+			return ResponseEntity.ok(authService.reissueToken(refreshToken));
+		} catch ( IllegalAccessException e) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Item Not Found");
+		}
+	}
+}

--- a/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
+++ b/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
@@ -2,6 +2,7 @@ package com.dndoz.PosePicker.Controller;
 
 import com.dndoz.PosePicker.Dto.KakaoLoginRequest;
 import com.dndoz.PosePicker.Dto.LoginResponse;
+import com.dndoz.PosePicker.Dto.LogoutRequest;
 import com.dndoz.PosePicker.Dto.PPTokenResponse;
 import com.dndoz.PosePicker.Global.status.StatusResponse;
 import com.dndoz.PosePicker.Service.AppleService;
@@ -67,6 +68,16 @@ public class UserController {
 		try{
 			return ResponseEntity.ok(appleService.appleLogin(idToken));
 		} catch (NoSuchElementException e) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND,"Item Not Found");
+		}
+	}
+
+	@PatchMapping("/logout")
+	@ApiOperation(value = "로그아웃", notes = "로그아웃 하기")
+	public ResponseEntity<StatusResponse> logout(@RequestBody LogoutRequest logoutRequest) {
+		try{
+			return ResponseEntity.ok(kakaoService.logout(logoutRequest));
+		} catch (NoSuchElementException | IllegalAccessException e) {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND,"Item Not Found");
 		}
 	}

--- a/src/main/java/com/dndoz/PosePicker/Dto/LogoutRequest.java
+++ b/src/main/java/com/dndoz/PosePicker/Dto/LogoutRequest.java
@@ -1,0 +1,11 @@
+package com.dndoz.PosePicker.Dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LogoutRequest {
+	private String accessToken;
+	private String refreshToken;
+}

--- a/src/main/java/com/dndoz/PosePicker/Global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/dndoz/PosePicker/Global/error/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import org.springframework.web.multipart.MultipartException;
 
 import com.dndoz.PosePicker.Global.error.exception.BookmarkException;
 import com.dndoz.PosePicker.Global.error.exception.BusinessException;
+import com.dndoz.PosePicker.Global.error.exception.CustomTokenException;
 import com.dndoz.PosePicker.Global.error.exception.ErrorCode;
 
 
@@ -152,4 +153,19 @@ public class GlobalExceptionHandler {
 		final ErrorResponse response = ErrorResponse.of(ErrorCode.BOOKMARK_BAD_REQUEST);
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
+
+	//로그아웃 & 토큰 재발급 시 에러
+	@ExceptionHandler(CustomTokenException.class)
+	public ResponseEntity<ErrorResponse> handleCustomTokenException(CustomTokenException e) {
+    	if (e.getMessage().equals("로그아웃 된 토큰 입니다")) {
+			final ErrorResponse response = ErrorResponse.of(ErrorCode.LOGOUT_JWT_TOKEN);
+			return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+		}
+    	//일치하는 refreshToken 존재X
+    	else {
+			final ErrorResponse response = ErrorResponse.of(ErrorCode.ENTITY_NOT_FOUND_JWT_TOKEN);
+			return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+		}
+	}
+
 }

--- a/src/main/java/com/dndoz/PosePicker/Global/error/exception/CustomTokenException.java
+++ b/src/main/java/com/dndoz/PosePicker/Global/error/exception/CustomTokenException.java
@@ -1,0 +1,14 @@
+package com.dndoz.PosePicker.Global.error.exception;
+
+public class CustomTokenException extends RuntimeException {
+	private ErrorCode errorCode;
+
+	public CustomTokenException(String message, ErrorCode errorCode) {
+		super(message);
+		this.errorCode = errorCode;
+	}
+
+	public CustomTokenException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/dndoz/PosePicker/Global/error/exception/ErrorCode.java
+++ b/src/main/java/com/dndoz/PosePicker/Global/error/exception/ErrorCode.java
@@ -20,8 +20,9 @@ public enum ErrorCode {
 	MALFORMED_JWT_TOKEN(401,"C012","MalformedJwtException 잘못된 jwt 구조"),
 	EXPIRED_JWT_TOKEN(401,"C013","ExpiredJwtException 토큰 만료"),
 	UNAUTHORIZED_JWT_TOKEN(401,"C014","Unauthorized"),
-
-	BOOKMARK_BAD_REQUEST(400,"C015","북마크 API 잘못된 요청")
+	LOGOUT_JWT_TOKEN(401,"C015","로그아웃 된 토큰 입니다."),
+	ENTITY_NOT_FOUND_JWT_TOKEN(401,"C016","일치하는 Refresh Token 존재하지 않습니다."),
+	BOOKMARK_BAD_REQUEST(400,"C017","북마크 API 잘못된 요청")
 	;
 
 

--- a/src/main/java/com/dndoz/PosePicker/Service/AuthService.java
+++ b/src/main/java/com/dndoz/PosePicker/Service/AuthService.java
@@ -1,0 +1,44 @@
+package com.dndoz.PosePicker.Service;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.dndoz.PosePicker.Auth.AuthTokens;
+import com.dndoz.PosePicker.Auth.AuthTokensGenerator;
+import com.dndoz.PosePicker.Auth.JwtTokenProvider;
+import com.dndoz.PosePicker.Domain.User;
+import com.dndoz.PosePicker.Global.error.exception.CustomTokenException;
+import com.dndoz.PosePicker.Repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+
+public class AuthService {
+	private final AuthTokensGenerator authTokensGenerator;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final UserRepository userRepository;
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public AuthTokens reissueToken(String refreshToken) throws IllegalAccessException {
+
+		String token=jwtTokenProvider.extractJwtToken(refreshToken);
+		if (!jwtTokenProvider.validateToken(token)){
+			return null;
+		}
+
+		//재발급하기 위해 일치하는 refresh 토큰 찾아서 uid 값 가져오기
+		String uid = jwtTokenProvider.findRefreshToken(token);
+		if (uid == null) {
+			throw new CustomTokenException("일치하는 Refresh Token이 존재하지 않습니다");
+		}
+
+		redisTemplate.delete("refresh:"+token);
+		User user=userRepository.findById(Long.valueOf(uid)).orElseThrow(NullPointerException::new);
+
+		// uid 매개변수로 token 다시 생성
+		AuthTokens newCreatedToken=authTokensGenerator.generate(user.getUid().toString());
+
+		return newCreatedToken;
+	}
+}


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 신규 피처

## 💁 무엇이 어떻게 바뀌나요?

1. redis 환경 세팅 (RedisTemplate을 이용한 방식)
2. accessToken 만료 시 refreshToken으로 재발급 API 구현 (로그인할때 redis에 `key: value`로 `"refresh"+refreshToken: userId`을 저장하여 토큰 재발급 요청시 refreshToken 유효성 검증 및 일치 여부 확인하여 재발급 하도록 했습니다!)
3. 로그아웃 API 구현 (로그아웃 시 redis에 `key:value`로 `accessToken:"logout"` 을 저장하였고 로그아웃된 accessToken으로 북마크or포즈피드 요청 시 예외처리도 했습니다.)
4. 토큰 재발급 예외처리 (일치하는 refreshToken 존재하지 않음) 및 로그아웃 예외처리 (로그아웃된 accessToken)

## 📆 작업 예정인 것이 있나요 ?
- 회원탈퇴 로직 수정

## 💬 리뷰어분들께
- redis 관련 정보(host, port, password) applications.properties 파일에 추가했으니 나중에 배포할때 같이 넣어주세요~!!
- 지난번에 애플과 카카오 로그인 구현하면서 아예 Service도 분리했어서 현재 로그아웃과 탈퇴하기 기능을 KakaoService에 구현했어요...! 근데 공통된 기능이기 때문에 탈퇴하기 수정하면서 Service 이름 수정하던지 새로 만들겠습니당...!!

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, design, refactor, test, add, set, docs, chore
-->
