### PR TITLE
fix: 탈퇴하기 API

### DIFF
--- a/src/main/java/com/dndoz/PosePicker/Auth/JwtTokenProvider.java
+++ b/src/main/java/com/dndoz/PosePicker/Auth/JwtTokenProvider.java
@@ -83,7 +83,7 @@ public class JwtTokenProvider {
 			Jws<Claims> claims = Jwts.parser().setSigningKey(key).parseClaimsJws(token);
 			//Redis에 있는 엑세스 토큰인 경우 로그아웃 처리된 엑세스 토큰임.
 			if (hasKeyBlackList(token)){
-				throw new CustomTokenException("로그아웃 된 토큰 입니다");
+				throw new CustomTokenException("로그아웃/탈퇴 된 토큰 입니다");
 			}
 			return !claims.getBody().getExpiration().before(new Date());
 		} catch (ExpiredJwtException e) {

--- a/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
+++ b/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
@@ -1,5 +1,6 @@
 package com.dndoz.PosePicker.Controller;
 
+import com.dndoz.PosePicker.Dto.DeleteAccountRequest;
 import com.dndoz.PosePicker.Dto.KakaoLoginRequest;
 import com.dndoz.PosePicker.Dto.LoginResponse;
 import com.dndoz.PosePicker.Dto.LogoutRequest;
@@ -32,11 +33,11 @@ public class UserController {
     @ResponseBody
     @GetMapping("/login/oauth/kakao")
 	@ApiOperation(value = "웹 카카오 로그인", notes = "웹 프론트 버전 카카오 로그인")
-    public ResponseEntity<LoginResponse> kakaoLogin(@RequestParam String code, HttpServletRequest request){
+    public ResponseEntity<LoginResponse> kakaoLogin(@RequestParam String code, @RequestParam String redirectURI){
         try{
 			// 현재 도메인 확인
-			String currentDomain = request.getServerName();
-            return ResponseEntity.ok(kakaoService.kakaoLogin(code, currentDomain));
+			//String currentDomain = request.getServerName();
+            return ResponseEntity.ok(kakaoService.kakaoLogin(code, redirectURI));
         } catch (NoSuchElementException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND,"Item Not Found");
         }

--- a/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
+++ b/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
@@ -84,12 +84,11 @@ public class UserController {
 	}
 
 	@ResponseBody
-	@DeleteMapping("/deleteAccount")
+	@PatchMapping("/deleteAccount")
 	@ApiOperation(value = "탈퇴하기", notes = "북마크 정보 삭제 후 회원 탈퇴")
-	public ResponseEntity<StatusResponse> deleteAccount(
-		@RequestHeader(value= "Authorization", required=false) String accessToken){
+	public ResponseEntity<StatusResponse> deleteAccount(@RequestBody DeleteAccountRequest deleteAccountRequest){
 		try{
-			return ResponseEntity.ok(kakaoService.deleteAccount(accessToken));
+			return ResponseEntity.ok(kakaoService.deleteAccount(deleteAccountRequest));
 		} catch (NoSuchElementException | IllegalAccessException e) {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND,"Item Not Found");
 		}

--- a/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
+++ b/src/main/java/com/dndoz/PosePicker/Controller/UserController.java
@@ -83,12 +83,12 @@ public class UserController {
 	}
 
 	@ResponseBody
-	@DeleteMapping("/signOut")
+	@DeleteMapping("/deleteAccount")
 	@ApiOperation(value = "탈퇴하기", notes = "북마크 정보 삭제 후 회원 탈퇴")
-	public ResponseEntity<StatusResponse> signOut(
+	public ResponseEntity<StatusResponse> deleteAccount(
 		@RequestHeader(value= "Authorization", required=false) String accessToken){
 		try{
-			return ResponseEntity.ok(kakaoService.signOut(accessToken));
+			return ResponseEntity.ok(kakaoService.deleteAccount(accessToken));
 		} catch (NoSuchElementException | IllegalAccessException e) {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND,"Item Not Found");
 		}

--- a/src/main/java/com/dndoz/PosePicker/Domain/Withdrawal.java
+++ b/src/main/java/com/dndoz/PosePicker/Domain/Withdrawal.java
@@ -1,0 +1,33 @@
+package com.dndoz.PosePicker.Domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import com.dndoz.PosePicker.Global.entity.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "withdrawal")
+public class Withdrawal extends BaseEntity {
+	@Id
+	@Column(name="withdrawalId")
+	private Long withdrawalId;
+
+	@Column(name = "uid")
+	private Long uid;
+
+	@Column(name = "reason")
+	String reason;
+
+	public Withdrawal(Long uid, String reason) {
+		this.uid = uid;
+		this.reason = reason;
+	}
+}

--- a/src/main/java/com/dndoz/PosePicker/Dto/DeleteAccountRequest.java
+++ b/src/main/java/com/dndoz/PosePicker/Dto/DeleteAccountRequest.java
@@ -1,0 +1,12 @@
+package com.dndoz.PosePicker.Dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DeleteAccountRequest {
+	private String accessToken;
+	private String refreshToken;
+	private String withdrawalReason;
+}

--- a/src/main/java/com/dndoz/PosePicker/Repository/PoseInfoRepository.java
+++ b/src/main/java/com/dndoz/PosePicker/Repository/PoseInfoRepository.java
@@ -76,9 +76,8 @@ public interface PoseInfoRepository extends JpaRepository<PoseInfo, Long> {
 	@Query(value =
 		"SELECT p.*, GROUP_CONCAT(ta.attribute ORDER BY ta.attribute_id ASC) AS t_tag_attributes FROM pose_info p "
 			+ "JOIN tag t ON p.pose_id = t.pose_id " + "JOIN tag_attribute ta ON t.attribute_id = ta.attribute_id "
-			+ "JOIN bookmark b ON b.pose_id = p.pose_id "
-			+ "WHERE b.uid = :uid "
-			+ "GROUP BY p.pose_id ", nativeQuery = true)
+			+ "JOIN bookmark b ON b.pose_id = p.pose_id " + "WHERE b.uid = :uid "
+			+ "GROUP BY p.pose_id " + "ORDER BY b.updated_at DESC ", nativeQuery = true)
 	Slice<PoseInfo> findBookmark(@Param("uid") Long uid, Pageable pageable);
 
 }

--- a/src/main/java/com/dndoz/PosePicker/Repository/WithdrawalRepository.java
+++ b/src/main/java/com/dndoz/PosePicker/Repository/WithdrawalRepository.java
@@ -1,0 +1,8 @@
+package com.dndoz.PosePicker.Repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dndoz.PosePicker.Domain.Withdrawal;
+
+public interface WithdrawalRepository extends JpaRepository<Withdrawal,Long> {
+}

--- a/src/main/java/com/dndoz/PosePicker/Service/KakaoService.java
+++ b/src/main/java/com/dndoz/PosePicker/Service/KakaoService.java
@@ -248,7 +248,7 @@ public class KakaoService {
 	}
 
     //탈퇴하기
-	public StatusResponse signOut(String accessToken) throws IllegalAccessException {
+	public StatusResponse deleteAccount(String accessToken) throws IllegalAccessException {
 		String token=jwtTokenProvider.extractJwtToken(accessToken);
 		if (! jwtTokenProvider.validateToken(token)) {
 			return null;

--- a/src/main/java/com/dndoz/PosePicker/Service/KakaoService.java
+++ b/src/main/java/com/dndoz/PosePicker/Service/KakaoService.java
@@ -5,6 +5,9 @@ import com.dndoz.PosePicker.Auth.AuthTokensGenerator;
 import com.dndoz.PosePicker.Auth.JwtTokenProvider;
 import com.dndoz.PosePicker.Auth.PPJwtTokenProvider;
 import com.dndoz.PosePicker.Domain.User;
+//import com.dndoz.PosePicker.Domain.Withdrawal;
+import com.dndoz.PosePicker.Dto.BookmarkResponse;
+//import com.dndoz.PosePicker.Dto.DeleteAccountRequest;
 import com.dndoz.PosePicker.Dto.KakaoLoginRequest;
 import com.dndoz.PosePicker.Dto.LoginResponse;
 import com.dndoz.PosePicker.Dto.LogoutRequest;
@@ -14,10 +17,12 @@ import com.dndoz.PosePicker.Global.status.StatusResponse;
 import com.dndoz.PosePicker.Repository.BookmarkRepository;
 import com.dndoz.PosePicker.Repository.UserRepository;
 
+//import com.dndoz.PosePicker.Repository.WithdrawalRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.With;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +33,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -46,6 +52,7 @@ public class KakaoService {
 	private final PPJwtTokenProvider psJwTokenProvider;
 	private final RedisTemplate<String, String> redisTemplate;
 	private final BookmarkRepository bookmarkRepository;
+	//private final WithdrawalRepository withdrawalRepository;
 
 	/** [1] ios 버전 카카오 로그인 **/
 	//포즈피커 자체 토큰 생성 후 전달
@@ -85,9 +92,9 @@ public class KakaoService {
 	}
 
 	/** [2] Web 버전 카카오 로그인 **/
-    public LoginResponse kakaoLogin(String code, String currentDomain) {
+    public LoginResponse kakaoLogin(String code, String redirectUri) {
     	//0. 동적으로 redirect URI 선택
-		String redirectUri=selectRedirectUri(currentDomain);
+		//String redirectUri=selectRedirectUri(currentDomain);
 
         // 1. "인가 코드"로 "액세스 토큰" 요청
         String accessToken = getAccessToken(code, redirectUri);
@@ -110,22 +117,22 @@ public class KakaoService {
 	@Value("${kakao.redirect-uri.local}")
 	private String isThirdDomain;
 
-	//0. 도메인에 따라 동적으로 redirect URI 선택
-	private String selectRedirectUri(String currentDomain) {
-		logger.info("[dynamicRedirectUri] 카카오 로그인 Uri 요청");
-		logger.info(currentDomain);
-		String dynamicRedirectUri = "";
-
-		if ("posepicker.site".equals(currentDomain)) {
-			dynamicRedirectUri=isFirstDomain;
-		} else if ("api-posepicker.site".equals(currentDomain)) {
-			dynamicRedirectUri=isSecondDomain;
-		} else if ("localhost".equals(currentDomain)){ //localhost
-			dynamicRedirectUri=isThirdDomain;
-		}
-		logger.info(dynamicRedirectUri);
-		return dynamicRedirectUri;
-	}
+	// //0. 도메인에 따라 동적으로 redirect URI 선택
+	// private String selectRedirectUri(String currentDomain) {
+	// 	logger.info("[dynamicRedirectUri] 카카오 로그인 Uri 요청");
+	// 	logger.info(currentDomain);
+	// 	String dynamicRedirectUri = "";
+	//
+	// 	if ("www.posepicker.site".equals(currentDomain)) {
+	// 		dynamicRedirectUri=isFirstDomain;
+	// 	} else if ("develop.posepicker.site".equals(currentDomain)) {
+	// 		dynamicRedirectUri=isSecondDomain;
+	// 	} else if ("localhost:3000".equals(currentDomain)){ //localhost
+	// 		dynamicRedirectUri=isThirdDomain;
+	// 	}
+	// 	logger.info(dynamicRedirectUri);
+	// 	return dynamicRedirectUri;
+	// }
 
     //1. "인가 코드"로 "액세스 토큰" 요청
     private String getAccessToken(String code, String redirectUri) {


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 탈퇴하기 로직 수정 및 자잘한 기능 수정

## 💁 무엇이 어떻게 바뀌나요?

1. 기존에는 탈퇴하면 바로 사용자 & 북마크 정보가 없어지도록 구현 -> 현재는 탈퇴사유 저장, 사용자&북마크 정보는 1주일 후 삭제
2. 사용자&북마크 정보 삭제하는 SQL 스크립트를 만들어서 ec2 Crontab에 추가했습니다!

## 📆 작업 예정인 것이 있나요 ?

- 

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, design, refactor, test, add, set, docs, chore
-->
